### PR TITLE
Actions: Add Go cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,5 +15,13 @@ jobs:
         with:
           version: 1.13.9
 
+      - name: Go cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
       - name: Run Go tests
         run: go test -cover -v ./...


### PR DESCRIPTION
## Overview

Add Go Modules cache using [actions/cache@v1](https://github.com/actions/cache). (Go Modules [example](https://github.com/actions/cache/blob/f60097cd16988b176c31ed5e2db51d50a8d19a4e/examples.md#go---modules))

It caches the `~/go/pkg/mod` path with the key based on the hash of `go.sum` at the root of the repository:

https://github.com/yanyi/generate-multifields-gql/blob/e5ea65dcf88b0c3487b8f6c77b4bdab5f8f3983b/.github/workflows/ci.yml#L21-L22

### Output of CI

```log
✅ Go cache
▸ Run actions/cache@v1
Cache Size: ~1 MB (685004 B)
/bin/tar -xz -f /home/runner/work/_temp/56bd8a88-e8a3-474d-b374-4947c8006eb3/cache.tgz -C /home/runner/go/pkg/mod
Cache restored from key: Linux-go-48ce54e934dd1bb370371dcba519715eeb3ac2b4259105967255b83509b0da4b

✅ Run Go tests
▸ Run go test -cover -v ./...
?   	github.com/yanyi/generate-multifields-gql	[no test files]
?   	github.com/yanyi/generate-multifields-gql/cmd	[no test files]
?   	github.com/yanyi/generate-multifields-gql/internal/errwrapper	[no test files]
... (redacted for brevity)
PASS
coverage: 100.0% of statements
ok  	github.com/yanyi/generate-multifields-gql/internal/generate	0.004s	coverage: 100.0% of statements
```
