### PR TITLE
generate: Fix test cases

### DIFF
--- a/internal/generate/generate_test.go
+++ b/internal/generate/generate_test.go
@@ -21,16 +21,16 @@ func TestOutput(t *testing.T) {
 			name:    "Valid input with 3 repetitions",
 			startID: 1,
 			endID:   3,
-			inputStr: `createSomething$id: createSomething(id:$id) {
+			inputStr: `querySomething$id: querySomething(id:$id) {
   someField
 }`,
-			expected: `createSomething1: createSomething(id:1) {
+			expected: `querySomething1: querySomething(id:1) {
   someField
 }
-createSomething2: createSomething(id:2) {
+querySomething2: querySomething(id:2) {
   someField
 }
-createSomething3: createSomething(id:3) {
+querySomething3: querySomething(id:3) {
   someField
 }`,
 			expectErr: false,


### PR DESCRIPTION
## Overview

As we want to generate multiple mutations or queries for GraphQL, the given test cases' example should reflect that: making use of [GraphQL aliases](https://graphql.org/learn/queries/#aliases). After all, that is the main intention of creating this tool – for me to generate multiple queries or mutations easily given an input text format.

Also added an example for Go Doc to be able to process that. It should help people who are new to the repo to understand what the `generate.Output` function does:

https://github.com/yanyi/generate-multifields-gql/blob/e92aecd6554e75258fa941e12c85db7930ca20ac/internal/generate/generate_test.go#L96-L108

## Notes

_Tagging this as a `bug` because it's a fix for test cases._