### PR TITLE
CLI: Rename to drop -gql from CLI name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# generate-multifields-gql
+# generate-multifields
 
-`generate-multifields-gql` is a CLI library to help generate multiple fields of
+`generate-multifields` is a CLI library to help generate multiple fields of
 a given input format of your GraphQL queries or mutations, by repeating them for
 a number of times.
 
@@ -18,13 +18,13 @@ and GitHub Actions.
 
 ### Mutations
 
-As of the current version, `generate-multifields-gql` allows generating for
+As of the current version, `generate-multifields` allows generating for
 GraphQL mutations.
 
 Run by entering a start ID and end ID, together with an input file:
 
 ```sh
-generate-multifields-gql mutations -s 10 -e 15 -f hero.txt
+generate-multifields mutations -s 10 -e 15 -f hero.txt
 ```
 
 What the CLI does is to look for instances of `$id` in a given text and replace

--- a/cmd/mutations.go
+++ b/cmd/mutations.go
@@ -9,8 +9,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
-	"github.com/yanyi/generate-multifields-gql/internal/errwrapper"
-	"github.com/yanyi/generate-multifields-gql/internal/generate"
+	"github.com/yanyi/generate-multifields/internal/errwrapper"
+	"github.com/yanyi/generate-multifields/internal/generate"
 )
 
 var mutationsCmd = &cobra.Command{

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yanyi/generate-multifields-gql
+module github.com/yanyi/generate-multifields
 
 go 1.13
 

--- a/main.go
+++ b/main.go
@@ -1,8 +1,8 @@
 package main
 
 import (
-	"github.com/yanyi/generate-multifields-gql/cmd"
-	"github.com/yanyi/generate-multifields-gql/internal/errwrapper"
+	"github.com/yanyi/generate-multifields/cmd"
+	"github.com/yanyi/generate-multifields/internal/errwrapper"
 )
 
 func main() {


### PR DESCRIPTION
## Overview

Since this tool is for GraphQL, it can be used with a `queries` or `mutations` command like:

- `generate-multifields queries`
- `generate-multifields mutations`

There was no need for a `-gql`. Just to shorten the CLI's name a _slight_ bit.

## Notes

The repo will be renamed right after merging + CI passing post-merge.