### PR TITLE
Docker: Dockerize the CLI into a Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+.github/
+/vendor/
+*.md

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,49 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Go for use with actions
+        uses: actions/setup-go@v1.0.0
+        with:
+          version: 1.13.9
+
+      - name: Go cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build Docker image (PRs)
+        if: endsWith(github.ref, '/develop') == false
+        env:
+          IMAGE_NAME: yanyi/generate-multifields
+          BUILD_SHA: ${{ github.sha }}
+        run: |
+          export CLI_VERSION=pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+          echo "Building Docker image with $IMAGE_NAME:$CLI_VERSION with $BUILD_SHA"
+          docker build \
+            --build-arg CLI_VERSION=$CLI_VERSION \
+            --build-arg BUILD_SHA=$BUILD_SHA \
+            -t $IMAGE_NAME:$CLI_VERSION .
+
+      - name: Build Docker image (Staging)
+        if: endsWith(github.ref, '/develop')
+        env:
+          IMAGE_NAME: yanyi/generate-multifields
+          BUILD_SHA: ${{ github.sha }}
+        run: |
+          echo $IMAGE_NAME:staging - $BUILD_SHA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ jobs:
   build:
     runs-on: ubuntu-18.04
 
+    env:
+      IMAGE_NAME: yanyi/generate-multifields
+      BUILD_SHA: ${{ github.sha }}
+
     steps:
       - name: git checkout
         uses: actions/checkout@v2
@@ -29,9 +33,6 @@ jobs:
 
       - name: Build Docker image (PRs)
         if: endsWith(github.ref, '/develop') == false
-        env:
-          IMAGE_NAME: yanyi/generate-multifields
-          BUILD_SHA: ${{ github.sha }}
         run: |
           export CLI_VERSION=pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
           echo "Building Docker image with $IMAGE_NAME:$CLI_VERSION with $BUILD_SHA"
@@ -40,10 +41,15 @@ jobs:
             --build-arg BUILD_SHA=$BUILD_SHA \
             -t $IMAGE_NAME:$CLI_VERSION .
 
+      - name: Print CLI version (PRs)
+        if: endsWith(github.ref, '/develop') == false
+        run: |
+          export CLI_VERSION=pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+          docker run --rm $IMAGE_NAME:$CLI_VERSION version
+
       - name: Build Docker image (Staging)
         if: endsWith(github.ref, '/develop')
         env:
-          IMAGE_NAME: yanyi/generate-multifields
-          BUILD_SHA: ${{ github.sha }}
+          CLI_VERSION: staging
         run: |
           echo $IMAGE_NAME:staging - $BUILD_SHA

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,19 +18,6 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v2
 
-      - name: Setup Go for use with actions
-        uses: actions/setup-go@v1.0.0
-        with:
-          version: 1.13.9
-
-      - name: Go cache
-        uses: actions/cache@v1
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Build Docker image (PRs)
         if: endsWith(github.ref, '/develop') == false
         run: |

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -14,18 +14,20 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v2
 
+      - name: Set Docker tag
+        run: |
+          echo ::set-env name=IMAGE_TAG::pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
+
       - name: Build Docker image
         if: endsWith(github.ref, '/develop') == false
         run: |
-          export CLI_VERSION=pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
-          echo "Building Docker image with $IMAGE_NAME:$CLI_VERSION with $BUILD_SHA"
+          echo "Building Docker image with $IMAGE_NAME:$IMAGE_TAG with $BUILD_SHA"
           docker build \
-            --build-arg CLI_VERSION=$CLI_VERSION \
+            --build-arg CLI_VERSION=$IMAGE_TAG \
             --build-arg BUILD_SHA=$BUILD_SHA \
-            -t $IMAGE_NAME:$CLI_VERSION .
+            -t $IMAGE_NAME:$IMAGE_TAG .
 
       - name: Print CLI version
         if: endsWith(github.ref, '/develop') == false
         run: |
-          export CLI_VERSION=pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
-          docker run --rm $IMAGE_NAME:$CLI_VERSION version
+          docker run --rm $IMAGE_NAME:$IMAGE_TAG version

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -21,13 +21,13 @@ jobs:
       - name: Build Docker image
         if: endsWith(github.ref, '/develop') == false
         run: |
-          echo "Building Docker image with $IMAGE_NAME:$IMAGE_TAG with $BUILD_SHA"
+          echo "Building Docker image with ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} with ${{ env.BUILD_SHA }}"
           docker build \
-            --build-arg CLI_VERSION=$IMAGE_TAG \
-            --build-arg BUILD_SHA=$BUILD_SHA \
-            -t $IMAGE_NAME:$IMAGE_TAG .
+            --build-arg CLI_VERSION=${{ env.IMAGE_TAG }} \
+            --build-arg BUILD_SHA=${{ env.BUILD_SHA }} \
+            -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} .
 
       - name: Print CLI version
         if: endsWith(github.ref, '/develop') == false
         run: |
-          docker run --rm $IMAGE_NAME:$IMAGE_TAG version
+          docker run --rm ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} version

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,10 +1,6 @@
 name: Docker Build
 
-on:
-  push:
-    branches:
-      - develop
-  pull_request:
+on: [pull_request]
 
 jobs:
   build:
@@ -18,7 +14,7 @@ jobs:
       - name: git checkout
         uses: actions/checkout@v2
 
-      - name: Build Docker image (PRs)
+      - name: Build Docker image
         if: endsWith(github.ref, '/develop') == false
         run: |
           export CLI_VERSION=pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
@@ -28,15 +24,8 @@ jobs:
             --build-arg BUILD_SHA=$BUILD_SHA \
             -t $IMAGE_NAME:$CLI_VERSION .
 
-      - name: Print CLI version (PRs)
+      - name: Print CLI version
         if: endsWith(github.ref, '/develop') == false
         run: |
           export CLI_VERSION=pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
           docker run --rm $IMAGE_NAME:$CLI_VERSION version
-
-      - name: Build Docker image (Staging)
-        if: endsWith(github.ref, '/develop')
-        env:
-          CLI_VERSION: staging
-        run: |
-          echo $IMAGE_NAME:staging - $BUILD_SHA

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,32 +1,45 @@
-name: Docker Build
+name: Staging
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - develop
 
 jobs:
-  build:
+  build-and-push:
     runs-on: ubuntu-18.04
 
     env:
       IMAGE_NAME: yanyi/generate-multifields
+      IMAGE_TAG: latest
+      CLI_VERSION: staging
       BUILD_SHA: ${{ github.sha }}
 
     steps:
       - name: git checkout
         uses: actions/checkout@v2
 
-      - name: Set Docker tag
-        run: |
-          echo ::set-env name=IMAGE_TAG::pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
-
       - name: Build Docker image
-        if: endsWith(github.ref, '/develop') == false
+        if: endsWith(github.ref, '/develop')
         run: |
           echo "Building Docker image with ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}, commit ${{ env.BUILD_SHA }}."
           docker build \
-            --build-arg CLI_VERSION=${{ env.IMAGE_TAG }} \
+            --build-arg CLI_VERSION=${{ env.CLI_VERSION }} \
             --build-arg BUILD_SHA=${{ env.BUILD_SHA }} \
             -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} .
 
       - name: Print CLI version
-        if: endsWith(github.ref, '/develop') == false
+        if: endsWith(github.ref, '/develop')
         run: docker run --rm ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} version
+
+      - name: Docker login
+        if: success()
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push Docker image
+        if: success()
+        run: |
+          docker push ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,18 @@ ENV GO111MODULE=auto
 COPY . .
 RUN go get -v ./...
 
-RUN GOOS=linux GOARCH=386 go build -ldflags="-w -s" -o /go/bin/generate-multifields
+ARG CLI_VERSION
+ENV CLI_VERSION=${CLI_VERSION:-nil}
+ARG BUILD_SHA
+ENV BUILD_SHA=${BUILD_SHA:-nil}
+
+RUN GOOS=linux GOARCH=386 go build \
+  -ldflags="-w -s \
+  -X 'github.com/yanyi/generate-multifields/cmd.Version=$CLI_VERSION' \
+  -X 'github.com/yanyi/generate-multifields/cmd.Build=$BUILD_SHA'" \
+  -o /go/bin/generate-multifields
+
+##########
 
 FROM scratch
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /go/src/github.com/yanyi/generate-multifields
 ENV GO111MODULE=auto
 
 COPY go.mod go.sum ./
-RUN go get -v ./...
+RUN go mod download
 
 ARG CLI_VERSION
 ENV CLI_VERSION=${CLI_VERSION:-nil}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.13.9-alpine3.11 AS builder
+
+RUN apk update && apk add \
+  make \
+  git
+
+WORKDIR /go/src/github.com/yanyi/generate-multifields
+ENV GO111MODULE=auto
+
+COPY . .
+RUN go get -v ./...
+
+RUN GOOS=linux GOARCH=386 go build -ldflags="-w -s" -o /go/bin/generate-multifields
+
+FROM scratch
+
+COPY --from=builder /go/bin/generate-multifields /bin/generate-multifields
+
+ENTRYPOINT [ "/bin/generate-multifields" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apk update && apk add \
 WORKDIR /go/src/github.com/yanyi/generate-multifields
 ENV GO111MODULE=auto
 
-COPY . .
+COPY go.mod go.sum ./
 RUN go get -v ./...
 
 ARG CLI_VERSION
@@ -15,6 +15,7 @@ ENV CLI_VERSION=${CLI_VERSION:-nil}
 ARG BUILD_SHA
 ENV BUILD_SHA=${BUILD_SHA:-nil}
 
+COPY . .
 RUN GOOS=linux GOARCH=386 go build \
   -ldflags="-w -s \
   -X 'github.com/yanyi/generate-multifields/cmd.Version=$CLI_VERSION' \

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # generate-multifields
 
+![Staging](https://github.com/yanyi/generate-multifields/workflows/Staging/badge.svg?branch=develop)
+
 `generate-multifields` is a CLI library to help generate multiple fields of
 a given input format of your GraphQL queries or mutations, by repeating them for
 a number of times.
@@ -13,6 +15,31 @@ run by IDs. I needed a tool to generate them with a given input.
 
 Yes. It was also intended for me to play with [Cobra](https://github.com/spf13/cobra)
 and GitHub Actions.
+
+## Running
+
+### Go
+
+Install the CLI using:
+
+```sh
+go install
+```
+
+After that, use the CLI:
+
+```sh
+generate-multifields mutations -s 10 -e 15 -f hero.txt
+```
+
+### Docker
+
+Excluding the `docker pull` command, you can run this immediately:
+
+```sh
+docker run --rm -v $(pwd):/usr/ yanyi/generate-multifields:latest \
+    mutations -s 10 -e 15 -f /usr/hero.txt
+```
 
 ## Usage
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 )
@@ -11,18 +13,26 @@ var (
 	Version = "Development"
 	// Build is the Git SHA. Also replaceable with `-ldflags="-X"`.
 	Build = "4c17aadf5117487aab7bc50cbf056caf3977cc31"
-)
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version number of generate-multifields",
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("generate-multifields:")
-		fmt.Println(" Version:", Version)
-		fmt.Println(" Build:", Build)
-	},
-}
+	versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Print the version number of generate-multifields",
+		Run: func(cmd *cobra.Command, args []string) {
+			prettyPrint(cmd.OutOrStdout())
+		},
+	}
+)
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+}
+
+func prettyPrint(out io.Writer) {
+	fmt.Println("generate-multifields:")
+
+	w := tabwriter.NewWriter(out, 10, 1, 1, ' ', 0)
+	defer w.Flush()
+
+	fmt.Fprintln(w, " Version:\t", Version)
+	fmt.Fprintln(w, " Build:\t", Build)
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,13 +6,20 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const version = "v0.0.0"
+var (
+	// Version is the CLI's version. It can be replaced with `-ldflags="-X"`.
+	Version = "Development"
+	// Build is the Git SHA. Also replaceable with `-ldflags="-X"`.
+	Build = "4c17aadf5117487aab7bc50cbf056caf3977cc31"
+)
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print the version number of generate-multifields",
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("generate-multifields", version)
+		fmt.Println("generate-multifields:")
+		fmt.Println(" Version:", Version)
+		fmt.Println(" Build:", Build)
 	},
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,6 @@ require (
 	github.com/spf13/cobra v0.0.7
 	github.com/stretchr/testify v1.5.1
 )
+
+// Use local fork with relative on-disk location.
+replace github.com/yanyi/generate-multifields => ./


### PR DESCRIPTION
## Overview

Dockerize the CLI into a Docker image. 

This PR also includes two workflows:

1. Building Docker images only on pull requests.
2. Building the Docker image, tagging the image with `latest` and then pushing Docker image. All upon merge to `develop` branch.

Link to the Docker repository - https://hub.docker.com/r/yanyi/generate-multifields