### PR TITLE
Git: Migrate to `master` branch as staging

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -19,7 +19,7 @@ jobs:
           echo ::set-env name=IMAGE_TAG::pr-$(echo "$GITHUB_REF" | awk -F / '{print $3}')
 
       - name: Build Docker image
-        if: endsWith(github.ref, '/develop') == false
+        if: endsWith(github.ref, '/master') == false
         run: |
           echo "Building Docker image with ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}, commit ${{ env.BUILD_SHA }}."
           docker build \
@@ -28,5 +28,5 @@ jobs:
             -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} .
 
       - name: Print CLI version
-        if: endsWith(github.ref, '/develop') == false
+        if: endsWith(github.ref, '/master') == false
         run: docker run --rm ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} version

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -3,7 +3,7 @@ name: Staging
 on:
   push:
     branches:
-      - develop
+      - master
 
 jobs:
   build-and-push:
@@ -20,7 +20,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build Docker image
-        if: endsWith(github.ref, '/develop')
+        if: endsWith(github.ref, '/master')
         run: |
           echo "Building Docker image with ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}, commit ${{ env.BUILD_SHA }}."
           docker build \
@@ -29,7 +29,7 @@ jobs:
             -t ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} .
 
       - name: Print CLI version
-        if: endsWith(github.ref, '/develop')
+        if: endsWith(github.ref, '/master')
         run: docker run --rm ${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }} version
 
       - name: Docker login


### PR DESCRIPTION
## Overview

Instead of working off a `develop` branch, make use of the `master` branch as staging. Afterwards, release process should be based off the `master` branch.

## Notes

The `develop` branch will be removed after merging `develop` into  `master` in a separate PR. New features/hotfixes/etc. should be based off `master`.
