### PR TITLE
root: Remove tabs for text alignment

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,8 +9,8 @@ var (
 		Use:   "generate-multifields",
 		Short: "Generate multiple fields for GraphQL queries or mutations",
 		Long: `generate-multifields is a CLI library to help generate multiple
-	fields of a given input format of your GraphQL queries or mutations, by
-	repeating them for a number of times.`,
+fields of a given input format of your GraphQL queries or mutations, by
+repeating them for a number of times.`,
 	}
 
 	// StartID is the starting ID number to start with.


### PR DESCRIPTION
## Overview

Fixes #18.

TL;DR of issue: Text alignment issue when running `generate-multifields help`. Remove tabs from Go's multiline string.