### PR TITLE
README: Fix mounting directory for Docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ generate-multifields mutations -s 10 -e 15 -f hero.txt
 Excluding the `docker pull` command, you can run this immediately:
 
 ```sh
-docker run --rm -v $(pwd):/usr/ yanyi/generate-multifields:latest \
-    mutations -s 10 -e 15 -f /usr/hero.txt
+docker run --rm -v $(pwd):/tmp yanyi/generate-multifields:latest \
+    mutations -s 10 -e 15 -f /tmp/hero.txt
 ```
 
 ## Usage


### PR DESCRIPTION
## Overview

According to the Filesystem Hierarchy Standard (FHS), the `/usr` directory is for shareable and read-only data. A more appropriate place to mount the working directory should actually be `/tmp`.

This Pull Request fixes the instruction for mounting the working directory when using `docker run` to mount in the container's `/tmp` directory instead.

Refer to issue #21. As I want to think about improving the CLI, I don't want to close that issue, yet.
