### PR TITLE
Actions: Add release workflow

### DIFF
--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -1,9 +1,10 @@
-name: Docker Build
+name: Docker Build - Pull Request
 
 on: [pull_request]
 
 jobs:
   build:
+    name: Build Docker image on Pull Requests
     runs-on: ubuntu-18.04
 
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,36 @@ name: CI
 on: [push]
 
 jobs:
+  lint:
+    name: Go lint
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Go for use with actions
+        uses: actions/setup-go@v1.0.0
+        with:
+          version: 1.13.9
+
+      - name: Download golangci-lint
+        # Installs to ./bin since installing to /home/runner/go/bin/golangci-lint
+        # doesn't work - `line 1: golangci-lint: command not found`.
+        run: |
+          curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.24.0
+          ./bin/golangci-lint version
+
+      - name: Run golangci-lint
+        # Run with defaults https://github.com/golangci/golangci-lint/tree/1.24.0
+        # with additional `goimports` and `unused`.
+        run: |
+          ./bin/golangci-lint run \
+            -E goimports \
+            -E unused
+
   test:
+    name: Go tests
     runs-on: ubuntu-18.04
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,91 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  github-build-and-release:
+    name: Build Go binaries and release on GitHub
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: Setup Go for use with actions
+        uses: actions/setup-go@v1.0.0
+        with:
+          version: 1.13.9
+
+      - name: Go cache
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Run Go build for different OSes and architectures
+        run: |
+          TAG_WITHOUT_V=$(echo "$GITHUB_REF" | awk -F / '{print $3}' | awk -F v '{print $2}')
+          ./build-binaries $TAG_WITHOUT_V ${{ github.sha }}
+
+      - name: Run Go build for different OSes and architectures
+        run: |
+          TAG_WITHOUT_V=$(echo "$GITHUB_REF" | awk -F / '{print $3}' | awk -F v '{print $2}')
+          ./build-binaries $TAG_WITHOUT_V ${{ github.sha }}
+
+      - name: Create GitHub Release and upload assets
+        if: success() && startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          draft: false
+          prerelease: false
+          body_path: CHANGELOG.md
+          files: gmf-*
+
+  docker-build-and-push:
+    # Only release to Docker if GitHub's release is completed.
+    needs: github-build-and-release
+    name: Build release Docker image and push to Docker Hub
+    runs-on: ubuntu-18.04
+
+    env:
+      IMAGE_NAME: yanyi/generate-multifields
+      BUILD_SHA: ${{ github.sha }}
+
+    steps:
+      - name: git checkout
+        uses: actions/checkout@v2
+
+      - name: Set environment variables using Git tag (without 'v')
+        run: |
+          TAG_WITHOUT_V=$(echo "$GITHUB_REF" | awk -F / '{print $3}' | awk -F v '{print $2}')
+          echo ::set-env name=VERSION::$TAG_WITHOUT_V
+
+      - name: Build Docker image
+        run: |
+          echo "Building Docker image with ${{ env.IMAGE_NAME }}:${{ env.VERSION }}, commit ${{ env.BUILD_SHA }}."
+          docker build \
+            --build-arg CLI_VERSION=${{ env.VERSION }} \
+            --build-arg BUILD_SHA=${{ env.BUILD_SHA }} \
+            -t ${{ env.IMAGE_NAME }}:${{ env.VERSION }} .
+
+      - name: Print CLI version
+        run: docker run --rm ${{ env.IMAGE_NAME }}:${{ env.VERSION }} version
+
+      - name: Docker login
+        if: success()
+        uses: azure/docker-login@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Push Docker image
+        if: success()
+        run: |
+          docker push ${{ env.IMAGE_NAME }}:${{ env.VERSION }}

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   build-and-push:
+    name: Build staging Docker image and push to Docker Hub
     runs-on: ubuntu-18.04
 
     env:

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 
 # Built binary of repo
 generate-multifields
+gmf-*
 
 ### Go Patch ###
 /vendor/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 0.1.0 (2020-04-11)
+## v0.1.0 (2020-04-12)
 
 First version of the CLI.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## 0.1.0 (2020-04-11)
+
+First version of the CLI.
+
+### Features
+
+- Allow using the `mutations` command to read from file and output the result
+  to stdout.

--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ latest: Pulling from yanyi/generate-multifields
 
 ## Running
 
+Using a text file, the CLI looks for instances of `$id` and replaces it with
+the IDs when running the `mutations` command. Here is an example of a text file:
+
+```txt
+hero$id: updateHeroLocation(id: $id, location: "Missing") {
+  id
+  location
+}
+```
+
 For non-Docker, running the CLI is as simple as:
 
 ```sh
@@ -90,17 +100,7 @@ GraphQL mutations.
 Run by entering a start ID and end ID, together with an input file:
 
 ```sh
-gmf mutations -s 10 -e 15 -f hero.txt
-```
-
-What the CLI does is to look for instances of `$id` in a given text and replace
-it with the IDs. Here is an example of a text file:
-
-```txt
-hero$id: updateHeroLocation(id: $id, location: "Missing") {
-  id
-  location
-}
+$ gmf mutations -s 10 -e 15 -f hero.txt
 ```
 
 The CLI generates the output like:

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![Staging](https://github.com/yanyi/generate-multifields/workflows/Staging/badge.svg?branch=master)
 
-`generate-multifields` is a CLI library to help generate multiple fields of
+`generate-multifields` (`gmf`) is a CLI library to help generate multiple fields of
 a given input format of your GraphQL queries or mutations, by repeating them for
 a number of times.
 
@@ -16,42 +16,81 @@ run by IDs. I needed a tool to generate them with a given input.
 Yes. It was also intended for me to play with [Cobra](https://github.com/spf13/cobra)
 and GitHub Actions.
 
+## Downloading
+
+### Released Versions
+
+Get the latest binary for your OS/Architecture from the
+[Releases tab](https://github.com/yanyi/generate-multifields/releases/latest).
+The following is the `curl` instructions for macOS:
+
+```sh
+$ curl -L https://github.com/yanyi/generate-multifields/releases/latest/download/gmf-darwin_x86_64 > gmf && \
+  chmod +x gmf && \
+  mv gmf /usr/local/bin
+
+$ which gmf
+/usr/local/bin/gmf
+```
+
+Using Docker for released versions:
+
+```sh
+$ docker pull yanyi/generate-multifields:0.1.0
+0.1.0: Pulling from yanyi/generate-multifields
+```
+
+<!-- Collapse the developmental version instructions -->
+<details>
+  <summary>Development Version</summary>
+
+#### Go
+
+Clone the repository and run:
+
+```sh
+$ go build -i -o gmf && mv gmf /usr/local/bin
+
+$ which gmf
+/usr/local/bin/gmf
+```
+
+#### Docker
+
+```sh
+$ docker pull yanyi/generate-multifields:latest
+latest: Pulling from yanyi/generate-multifields
+```
+
+</details>
+<!-- End of collapsing developmental version instructions -->
+
 ## Running
 
-### Go
-
-Install the CLI using:
+For non-Docker, running the CLI is as simple as:
 
 ```sh
-go install
+$ gmf mutations -s 10 -e 15 -f hero.txt
 ```
 
-After that, use the CLI:
+For Docker, mount the working directory as volume (`-v` flag):
 
 ```sh
-generate-multifields mutations -s 10 -e 15 -f hero.txt
-```
-
-### Docker
-
-Excluding the `docker pull` command, you can run this immediately:
-
-```sh
-docker run --rm -v $(pwd):/tmp yanyi/generate-multifields:latest \
+$ docker run --rm -v $(pwd):/tmp yanyi/generate-multifields:latest \
     mutations -s 10 -e 15 -f /tmp/hero.txt
 ```
 
-## Usage
+## Commands
 
 ### Mutations
 
-As of the current version, `generate-multifields` allows generating for
+As of the current version, `gmf` allows generating for
 GraphQL mutations.
 
 Run by entering a start ID and end ID, together with an input file:
 
 ```sh
-generate-multifields mutations -s 10 -e 15 -f hero.txt
+gmf mutations -s 10 -e 15 -f hero.txt
 ```
 
 What the CLI does is to look for instances of `$id` in a given text and replace

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ $ docker run --rm -v $(pwd):/tmp yanyi/generate-multifields:latest \
     mutations -s 10 -e 15 -f /tmp/hero.txt
 ```
 
+**Tip for Docker users** - Add an `alias` for the Docker run instruction:
+
+```sh
+alias gmf="docker run --rm -v $(pwd):/tmp yanyi/generate-multifields:latest"
+```
+
 ## Commands
 
 ### Mutations

--- a/build-binaries
+++ b/build-binaries
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+VERSION=$1
+BUILD=$2
+if [ -z "$VERSION" ]; then
+    echo "Require argument for version"
+    exit 1
+fi
+if [ -z "$BUILD" ]; then
+    echo "Require argument for build"
+    exit 1
+fi
+
+echo "Building Go binaries"
+GOBUILD="go build \
+  -ldflags=\"-w -s \
+  -X 'github.com/yanyi/generate-multifields/cmd.Version=$VERSION' \
+  -X 'github.com/yanyi/generate-multifields/cmd.Build=$BUILD'\""
+
+# Build for Linux architectures.
+linuxArchs=(
+  "386"
+  "arm64"
+  "amd64"
+)
+for arch in "${linuxArchs[@]}"
+do
+  GOOS=linux GOARCH="$arch" eval $GOBUILD -o ./gmf-linux_$arch
+  echo "Built for Linux - gmf-linux_$arch"
+done
+
+# Build for macOS X86 64.
+GOOS=darwin GOARCH=amd64 eval $GOBUILD -o ./gmf-darwin_x86_64
+echo "Built for macOS - gmf-darwin_x86_64"
+
+# Build for Windows X86 64.
+GOOS=windows GOARCH=amd64 eval $GOBUILD -o ./gmf-win_amd64
+echo "Built for Windows - gmf-win_amd64"
+
+echo "Finished building Go binaries 🎉"

--- a/cmd/mutations.go
+++ b/cmd/mutations.go
@@ -18,9 +18,15 @@ var mutationsCmd = &cobra.Command{
 	Short: "Generate multiple fields of a given mutation format",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		// Require flags to be set before continuing with the run.
-		cobra.MarkFlagRequired(cmd.Flags(), "start")
-		cobra.MarkFlagRequired(cmd.Flags(), "end")
-		cobra.MarkFlagRequired(cmd.Flags(), "file-path")
+		if err := cobra.MarkFlagRequired(cmd.Flags(), "start"); err != nil {
+			errwrapper.Fatal(err)
+		}
+		if err := cobra.MarkFlagRequired(cmd.Flags(), "end"); err != nil {
+			errwrapper.Fatal(err)
+		}
+		if err := cobra.MarkFlagRequired(cmd.Flags(), "file-path"); err != nil {
+			errwrapper.Fatal(err)
+		}
 
 		if EndID < StartID {
 			err := errors.New("value of --end should not be lesser than --start")

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"runtime"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
@@ -35,4 +36,5 @@ func prettyPrint(out io.Writer) {
 
 	fmt.Fprintln(w, " Version:\t", Version)
 	fmt.Fprintln(w, " Build:\t", Build)
+	fmt.Fprintln(w, " OS/Arch:\t", fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH))
 }


### PR DESCRIPTION
## Overview

This Pull Request adds the release workflow in issue #16. The binary generated on GitHub Releases will be `gmf-os_arch`:

1. `gmf-linux_386`
2. `gmf-linux_arm64`
3. `gmf-linux_amd64`
4. `gmf-darwin_x86_64`
5. `gmf-win_amd64`

### Release Workflow

The Release workflow (05e56b3) will:

1. Build Go binaries and then upload them to GitHub Release.
2. Build the release Docker image and push to Docker Hub.

Also added additional OS and architecture information in the `version` command of the CLI (6ccdfa8).

### Linting

CI now lints on every push for the Go code, making use of [`golangci-lint`](https://github.com/golangci/golangci-lint/tree/1.24.0).

### Documentation

`CHANGELOG.md` has been added. It will also be used by the Release workflow, though currently it will take everything in the `CHANGELOG.md` and place it into the body of the release (4cf3fac, 5450b2f).

Documentation in `README.md` has been updated with instructions to `curl` from GitHub Releases or pull from Docker Hub.

Also added small documentation on tip for adding alias when running through Docker (7820ec4).